### PR TITLE
[Enhancement]: Move Format Settings from Design to Export tab

### DIFF
--- a/src/features/composer/input/input.tsx
+++ b/src/features/composer/input/input.tsx
@@ -65,11 +65,6 @@ function Input({ activitiesError, activitiesLoading, onLoadMore }: InputProps) {
           />
         </Tab>
         <Tab name="Design">
-          <Format
-            format={format}
-            formats={formats}
-            onFormatChange={setFormat}
-          />
           <Template
             template={template}
             templates={templates}
@@ -83,6 +78,11 @@ function Input({ activitiesError, activitiesLoading, onLoadMore }: InputProps) {
           <Controls variables={variables} onVariableChange={setVariable} />
         </Tab>
         <Tab name="Export">
+          <Format
+            format={format}
+            formats={formats}
+            onFormatChange={setFormat}
+          />
           <Export
             asset={asset}
             assets={assets}


### PR DESCRIPTION
## Summary
Moves format selection settings (Square, Portrait, Landscape, Story) from the Design tab to the Export tab for better semantic organization.

## Changes
- **Relocated Format component** from Design tab to Export tab in [input.tsx](src/features/composer/input/input.tsx)
- Format selector now appears above the Export controls in the Export tab
- No changes to functionality, state management, or component logic

## Rationale
Format is fundamentally an export/output concern rather than a design concern. This change:
- Groups format with export settings (asset type, download)
- Keeps Design tab focused on visual styling (template, preset, colors)
- Improves the logical organization of settings

## Before & After

**Before** (Design tab):
- Format ← moved
- Template
- Preset
- Controls

**After** (Design tab):
- Template
- Preset  
- Controls

**After** (Export tab):
- Format ← now here
- Export (asset type & download)

## Test Results
✅ Type-check passes
✅ Lint passes
✅ All 41 tests pass
✅ All functionality works as intended

Closes #50